### PR TITLE
✨ Feat 카테고리 전체 조회 기능 추가

### DIFF
--- a/src/main/java/com/devqoo/backend/category/controller/CategoryApiDocs.java
+++ b/src/main/java/com/devqoo/backend/category/controller/CategoryApiDocs.java
@@ -4,12 +4,6 @@ import com.devqoo.backend.category.dto.form.RegisterCategoryForm;
 import com.devqoo.backend.category.dto.response.CategoryResponseDto;
 import com.devqoo.backend.common.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
@@ -17,50 +11,23 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "Category", description = "카테고리 관련 API 입니다.")
 public interface CategoryApiDocs {
 
-    @RequestBody(
-        description = "카테고리 생성 폼", required = true,
-        content = @Content(schema = @Schema(implementation = RegisterCategoryForm.class))
-    )
+
     @Operation(summary = "카테고리 생성", description = "카테고리를 생성합니다.")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "카테고리 생성 성공"),
-        @ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
-        @ApiResponse(responseCode = "403", description = "권한 없음")
-    })
     ResponseEntity<CommonResponse<CategoryResponseDto>> createCategory(
         RegisterCategoryForm registerCategoryForm
     );
 
     @Operation(summary = "카테고리 목록 조회", description = "카테고리 목록을 조회합니다.")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "카테고리 목록 조회 성공")
-    })
     ResponseEntity<CommonResponse<List<CategoryResponseDto>>> getCategories();
 
-    @RequestBody(
-        description = "카테고리 수정 폼", required = true,
-        content = @Content(schema = @Schema(implementation = RegisterCategoryForm.class))
-    )
+
     @Operation(summary = "카테고리 수정", description = "카테고리를 수정합니다.")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "카테고리 수정 성공"),
-        @ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
-        @ApiResponse(responseCode = "404", description = "카테고리 없음"),
-        @ApiResponse(responseCode = "403", description = "권한 없음")
-    })
     ResponseEntity<CommonResponse<CategoryResponseDto>> updateCategory(
-        @Parameter(description = "카테고리 ID", example = "123") Long categoryId,
+        Long categoryId,
         RegisterCategoryForm registerCategoryForm
     );
 
     @Operation(summary = "카테고리 삭제", description = "카테고리를 삭제합니다.")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "204", description = "카테고리 삭제 성공"),
-        @ApiResponse(responseCode = "404", description = "카테고리 없음"),
-        @ApiResponse(responseCode = "403", description = "권한 없음")
-    })
-    ResponseEntity<CommonResponse<Void>> deleteCategory(
-        @Parameter(description = "카테고리 ID", example = "123") Long categoryId
-    );
+    ResponseEntity<CommonResponse<Void>> deleteCategory(Long categoryId);
 
 }

--- a/src/main/java/com/devqoo/backend/category/controller/CategoryController.java
+++ b/src/main/java/com/devqoo/backend/category/controller/CategoryController.java
@@ -38,8 +38,9 @@ public class CategoryController implements CategoryApiDocs {
 
     @GetMapping
     public ResponseEntity<CommonResponse<List<CategoryResponseDto>>> getCategories() {
-
-        return ResponseEntity.ok().build();
+        List<CategoryResponseDto> categories = categoryFacade.getCategories();
+        CommonResponse<List<CategoryResponseDto>> response = CommonResponse.success(HttpStatus.OK.value(), categories);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/{categoryId}")

--- a/src/main/java/com/devqoo/backend/category/service/CategoryFacade.java
+++ b/src/main/java/com/devqoo/backend/category/service/CategoryFacade.java
@@ -3,6 +3,7 @@ package com.devqoo.backend.category.service;
 import com.devqoo.backend.category.dto.form.RegisterCategoryForm;
 import com.devqoo.backend.category.dto.response.CategoryResponseDto;
 import com.devqoo.backend.category.entity.Category;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,5 +16,12 @@ public class CategoryFacade {
     public CategoryResponseDto createCategory(RegisterCategoryForm form) {
         Category category = categoryService.create(form);
         return new CategoryResponseDto(category);
+    }
+
+    public List<CategoryResponseDto> getCategories() {
+        List<Category> categories = categoryService.findAll();
+        return categories.stream()
+            .map(CategoryResponseDto::new)
+            .toList();
     }
 }

--- a/src/main/java/com/devqoo/backend/category/service/CategoryService.java
+++ b/src/main/java/com/devqoo/backend/category/service/CategoryService.java
@@ -5,6 +5,7 @@ import com.devqoo.backend.category.entity.Category;
 import com.devqoo.backend.category.repository.CategoryRepository;
 import com.devqoo.backend.common.exception.BusinessException;
 import com.devqoo.backend.common.exception.ErrorCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,5 +24,10 @@ public class CategoryService {
         }
         Category category = new Category(categoryName);
         return categoryRepository.save(category);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Category> findAll() {
+        return categoryRepository.findAll();
     }
 }

--- a/src/test/java/com/devqoo/backend/category/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/devqoo/backend/category/repository/CategoryRepositoryTest.java
@@ -52,4 +52,5 @@ class CategoryRepositoryTest {
         // then
         assertThat(isExists).isFalse();
     }
+
 }

--- a/src/test/java/com/devqoo/backend/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/devqoo/backend/category/service/CategoryServiceTest.java
@@ -55,4 +55,5 @@ class CategoryServiceTest {
         assertThatThrownBy(() -> categoryService.create(form))
             .isInstanceOf(BusinessException.class);
     }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
머지 ❌ ❌ ❌ ❌ ❌ 
ref  #11 
> ex) #이슈번호, #이슈번호

## 작업 상세 내용
**여러분 컬럼이 변경됨에 따라서 데이터베이스 테이블 변경이 필요합니다. 
노션에 홈 -> 데이터베이스 페이지 -> sql 스크립트로 최신화 해주세요.**

`category_order  SMALLINT NOT NULL` 카테고리 데이터베이스 컬럼 추가
> 카테고리 숫자는 30_000 을 넘어가지 않을 것으로 예상하여 해당 컬럼 타입을 선택하였습니다.

- [x] 카테고리 전체 조회 API 
- [x] 카테고리 전체 조회 DB Query

- [ ] API 테스트 코드 작성

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 카테고리 순서를 위한 order 컬럼을 추가하였습니다. 프론트에서 해당 순서를 이용해서 화면을 구성하도록 하면 좋을 것 같습니다.
- 이후에 관리자 페이지에서 순서를 변경하고자 할 때 로직이 필요해졌습니다. 이에 로직을 구현해야할 것 같습니다.