### PR TITLE
카테고리 수정 MVC 기능 구현

### DIFF
--- a/src/main/java/com/devqoo/backend/category/controller/CategoryApiDocs.java
+++ b/src/main/java/com/devqoo/backend/category/controller/CategoryApiDocs.java
@@ -1,5 +1,6 @@
 package com.devqoo.backend.category.controller;
 
+
 import com.devqoo.backend.category.dto.form.RegisterCategoryForm;
 import com.devqoo.backend.category.dto.response.CategoryResponseDto;
 import com.devqoo.backend.common.response.CommonResponse;
@@ -11,15 +12,11 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "Category", description = "카테고리 관련 API 입니다.")
 public interface CategoryApiDocs {
 
-
     @Operation(summary = "카테고리 생성", description = "카테고리를 생성합니다.")
-    ResponseEntity<CommonResponse<CategoryResponseDto>> createCategory(
-        RegisterCategoryForm registerCategoryForm
-    );
+    ResponseEntity<CommonResponse<CategoryResponseDto>> createCategory(RegisterCategoryForm registerCategoryForm);
 
     @Operation(summary = "카테고리 목록 조회", description = "카테고리 목록을 조회합니다.")
     ResponseEntity<CommonResponse<List<CategoryResponseDto>>> getCategories();
-
 
     @Operation(summary = "카테고리 수정", description = "카테고리를 수정합니다.")
     ResponseEntity<CommonResponse<CategoryResponseDto>> updateCategory(

--- a/src/main/java/com/devqoo/backend/category/controller/CategoryController.java
+++ b/src/main/java/com/devqoo/backend/category/controller/CategoryController.java
@@ -49,8 +49,8 @@ public class CategoryController implements CategoryApiDocs {
         @RequestBody @Valid RegisterCategoryForm registerCategoryForm
     ) {
         CategoryResponseDto categoryResponseDto = categoryFacade.updateCategory(categoryId, registerCategoryForm);
-        CommonResponse<CategoryResponseDto> categoryResponse = CommonResponse.success(HttpStatus.OK.value(),
-            categoryResponseDto);
+        CommonResponse<CategoryResponseDto> categoryResponse =
+            CommonResponse.success(HttpStatus.OK.value(), categoryResponseDto);
         return ResponseEntity.ok(categoryResponse);
     }
 

--- a/src/main/java/com/devqoo/backend/category/controller/CategoryController.java
+++ b/src/main/java/com/devqoo/backend/category/controller/CategoryController.java
@@ -48,7 +48,10 @@ public class CategoryController implements CategoryApiDocs {
         @PathVariable Long categoryId,
         @RequestBody @Valid RegisterCategoryForm registerCategoryForm
     ) {
-        return ResponseEntity.ok().build();
+        CategoryResponseDto categoryResponseDto = categoryFacade.updateCategory(categoryId, registerCategoryForm);
+        CommonResponse<CategoryResponseDto> categoryResponse = CommonResponse.success(HttpStatus.OK.value(),
+            categoryResponseDto);
+        return ResponseEntity.ok(categoryResponse);
     }
 
     @DeleteMapping("/{categoryId}")

--- a/src/main/java/com/devqoo/backend/category/entity/Category.java
+++ b/src/main/java/com/devqoo/backend/category/entity/Category.java
@@ -26,10 +26,12 @@ public class Category extends BaseTimeEntity {
     @Column(name = "category_name", nullable = false, length = 50)
     private String categoryName;
 
-
     @Builder
     public Category(String categoryName) {
         this.categoryName = categoryName;
     }
 
+    public void update(String categoryName) {
+        this.categoryName = categoryName;
+    }
 }

--- a/src/main/java/com/devqoo/backend/category/service/CategoryFacade.java
+++ b/src/main/java/com/devqoo/backend/category/service/CategoryFacade.java
@@ -24,4 +24,9 @@ public class CategoryFacade {
             .map(CategoryResponseDto::new)
             .toList();
     }
+
+    public CategoryResponseDto updateCategory(Long categoryId, RegisterCategoryForm form) {
+        Category category = categoryService.update(categoryId, form);
+        return new CategoryResponseDto(category);
+    }
 }

--- a/src/main/java/com/devqoo/backend/category/service/CategoryService.java
+++ b/src/main/java/com/devqoo/backend/category/service/CategoryService.java
@@ -54,4 +54,10 @@ public class CategoryService {
         return categoryRepository.findById(categoryId)
             .orElseThrow(() -> new BusinessException(CATEGORY_NOT_FOUND));
     }
+
+    // TODO 소프트 삭제, 하드 삭제 구현 여부 상의하기
+    @Transactional
+    public void deleteById(Long categoryId) {
+        categoryRepository.deleteById(categoryId);
+    }
 }

--- a/src/main/java/com/devqoo/backend/category/service/CategoryService.java
+++ b/src/main/java/com/devqoo/backend/category/service/CategoryService.java
@@ -30,4 +30,16 @@ public class CategoryService {
     public List<Category> findAll() {
         return categoryRepository.findAll();
     }
+
+    @Transactional
+    public Category update(Long categoryId, RegisterCategoryForm registerCategoryForm) {
+        Category category = categoryRepository.findById(categoryId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
+        String categoryName = registerCategoryForm.categoryName();
+        if (categoryRepository.existsByCategoryName(categoryName)) {
+            throw new BusinessException(ErrorCode.CATEGORY_NAME_DUPLICATED);
+        }
+        category.update(categoryName);
+        return category;
+    }
 }

--- a/src/test/java/com/devqoo/backend/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/devqoo/backend/category/controller/CategoryControllerTest.java
@@ -2,6 +2,7 @@ package com.devqoo.backend.category.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -15,6 +16,7 @@ import com.devqoo.backend.common.config.SecurityConfig;
 import com.devqoo.backend.common.exception.BusinessException;
 import com.devqoo.backend.common.exception.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -81,6 +83,40 @@ class CategoryControllerTest {
                 .content(objectMapper.writeValueAsString(form)))
             .andExpect(status().isConflict())
             .andExpect(jsonPath("$.errorMessageList[0]").value(ErrorCode.CATEGORY_NAME_DUPLICATED.getMessage()))
+            .andDo(print());
+
+    }
+
+    @DisplayName("POST /api/categories - 카테고리 생성 실패 - 잘못된 요청")
+    @Test
+    void shouldReturn400_whenRequestBodyIsInvalid() throws Exception {
+        // given
+        RegisterCategoryForm form = new RegisterCategoryForm("");
+
+        // when && then
+        mockMvc.perform(post("/api/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(form)))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+    }
+
+    @DisplayName("GET /api/categories - 카테고리 목록 조회")
+    @Test
+    void shouldReturnCategoryList() throws Exception {
+        // given
+        List<CategoryResponseDto> responseDtos = List.of(
+            new CategoryResponseDto(1L, "질문 게시판"),
+            new CategoryResponseDto(2L, "자유 게시판")
+        );
+        given(categoryFacade.getCategories()).willReturn(responseDtos);
+
+        // when && then
+        mockMvc.perform(get("/api/categories")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data").isArray())
+            .andExpect(jsonPath("$.data.length()").value(2))
             .andDo(print());
 
     }

--- a/src/test/java/com/devqoo/backend/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/devqoo/backend/category/controller/CategoryControllerTest.java
@@ -3,6 +3,7 @@ package com.devqoo.backend.category.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -19,6 +20,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -119,5 +123,25 @@ class CategoryControllerTest {
             .andExpect(jsonPath("$.data.length()").value(2))
             .andDo(print());
 
+    }
+
+    @DisplayName("PATCH /api/categories/{categoryId} - 유효하지 않은 카테고리 이름은 2글자 제한 400 반환")
+    @ParameterizedTest
+    @ValueSource(strings = {"일"})
+    @NullAndEmptySource
+    void shouldReturn400_whenRequestIsInvalid(String invalidNewName) throws Exception {
+        // given
+        Long categoryId = 1L;
+        RegisterCategoryForm requestDto = new RegisterCategoryForm(invalidNewName);
+//        CategoryResponseDto expectResponse = new CategoryResponseDto(new Category(invalidNewName));
+//        when(categoryFacade.updateCategory(anyLong(), requestDto))
+//            .thenThrow(new Exception());
+
+        // when & then
+        mockMvc.perform(patch("/api/categories/" + categoryId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
     }
 }

--- a/src/test/java/com/devqoo/backend/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/devqoo/backend/category/controller/CategoryControllerTest.java
@@ -1,83 +1,87 @@
-//package com.devqoo.backend.category.controller;
-//
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.BDDMockito.given;
-//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-//import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-//
-//import com.devqoo.backend.category.dto.form.RegisterCategoryForm;
-//import com.devqoo.backend.category.dto.response.CategoryResponseDto;
-//import com.devqoo.backend.category.service.CategoryFacade;
-//import com.devqoo.backend.common.config.SecurityConfig;
-//import com.devqoo.backend.common.exception.BusinessException;
-//import com.devqoo.backend.common.exception.ErrorCode;
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.ArgumentMatchers;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-//import org.springframework.context.annotation.Import;
-//import org.springframework.http.MediaType;
-//import org.springframework.test.context.bean.override.mockito.MockitoBean;
-//import org.springframework.test.web.servlet.MockMvc;
-//
-//@WebMvcTest(CategoryController.class)
-//@AutoConfigureMockMvc
-//@Import({SecurityConfig.class})
-//class CategoryControllerTest {
-//
-//    @Autowired
-//    private MockMvc mockMvc;
-//
-//    @MockitoBean
-//    private CategoryFacade categoryFacade;
-//
-//    @Autowired
-//    private ObjectMapper objectMapper;
-//
-//    @DisplayName("POST /api/categories - 카테고리 생성")
-//    @Test
-//    void shouldCreateCategoryAndReturn201() throws Exception {
-//        // given
-//        long categoryId = 1L;
-//        String categoryName = "질문 게시판";
-//        RegisterCategoryForm form = new RegisterCategoryForm(categoryName);
-//        CategoryResponseDto responseDto = new CategoryResponseDto(categoryId, categoryName);
-//
-//        given(categoryFacade.createCategory(ArgumentMatchers.any(RegisterCategoryForm.class)))
-//            .willReturn(responseDto);
-//
-//        // when && then
-//        mockMvc.perform(post("/api/categories")
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(objectMapper.writeValueAsString(form)))
-//            .andExpect(status().isCreated())
-//            .andExpect(jsonPath("$.data.categoryId").value(categoryId))
-//            .andExpect(jsonPath("$.data.categoryName").value(categoryName))
-//            .andDo(print());
-//    }
-//
-//    @DisplayName("POST /api/categories - 카테고리 생성 실패")
-//    @Test
-//    void writeHereTestName() throws Exception {
-//        // given
-//        String categoryName = "질문 게시판";
-//        RegisterCategoryForm form = new RegisterCategoryForm(categoryName);
-//
-//        given(categoryFacade.createCategory(any()))
-//            .willThrow(new BusinessException(ErrorCode.CATEGORY_NAME_DUPLICATED));
-//        // when && then
-//
-//        mockMvc.perform(post("/api/categories")
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(objectMapper.writeValueAsString(form)))
-//            .andExpect(status().isConflict())
-//            .andExpect(jsonPath("$.errorMessageList[0]").value(ErrorCode.CATEGORY_NAME_DUPLICATED.getMessage()))
-//            .andDo(print());
-//
-//    }
-//}
+package com.devqoo.backend.category.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.devqoo.backend.auth.jwt.JwtProvider;
+import com.devqoo.backend.category.dto.form.RegisterCategoryForm;
+import com.devqoo.backend.category.dto.response.CategoryResponseDto;
+import com.devqoo.backend.category.service.CategoryFacade;
+import com.devqoo.backend.common.config.SecurityConfig;
+import com.devqoo.backend.common.exception.BusinessException;
+import com.devqoo.backend.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CategoryController.class)
+@AutoConfigureMockMvc
+@Import({SecurityConfig.class})
+class CategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CategoryFacade categoryFacade;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @DisplayName("POST /api/categories - 카테고리 생성")
+    @Test
+    void shouldCreateCategoryAndReturn201() throws Exception {
+        // given
+        long categoryId = 1L;
+        String categoryName = "질문 게시판";
+        RegisterCategoryForm form = new RegisterCategoryForm(categoryName);
+        CategoryResponseDto responseDto = new CategoryResponseDto(categoryId, categoryName);
+
+        given(categoryFacade.createCategory(ArgumentMatchers.any(RegisterCategoryForm.class)))
+            .willReturn(responseDto);
+
+        // when && then
+        mockMvc.perform(post("/api/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(form)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.data.categoryId").value(categoryId))
+            .andExpect(jsonPath("$.data.categoryName").value(categoryName))
+            .andDo(print());
+    }
+
+    @DisplayName("POST /api/categories - 카테고리 생성 실패")
+    @Test
+    void writeHereTestName() throws Exception {
+        // given
+        String categoryName = "질문 게시판";
+        RegisterCategoryForm form = new RegisterCategoryForm(categoryName);
+
+        given(categoryFacade.createCategory(any()))
+            .willThrow(new BusinessException(ErrorCode.CATEGORY_NAME_DUPLICATED));
+        // when && then
+
+        mockMvc.perform(post("/api/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(form)))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.errorMessageList[0]").value(ErrorCode.CATEGORY_NAME_DUPLICATED.getMessage()))
+            .andDo(print());
+
+    }
+}

--- a/src/test/java/com/devqoo/backend/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/devqoo/backend/category/service/CategoryServiceTest.java
@@ -10,6 +10,7 @@ import com.devqoo.backend.category.entity.Category;
 import com.devqoo.backend.category.repository.CategoryRepository;
 import com.devqoo.backend.common.exception.BusinessException;
 import com.devqoo.backend.provider.EntityProvider;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,4 +57,22 @@ class CategoryServiceTest {
             .isInstanceOf(BusinessException.class);
     }
 
+    @DisplayName("update: 카테고리 수정 테스트")
+    @Test
+//    @Disabled("수정 테스트는 아직 구현되지 않음")
+    void shouldUpdateCategory_whenCategoryExists() {
+        // given
+        Category category = EntityProvider.createCategory(CATEGORY_NAME);
+        given(categoryRepository.findById(any())).willReturn(Optional.of(category));
+
+        String newCategoryName = "New Category Name";
+        RegisterCategoryForm form = new RegisterCategoryForm(newCategoryName);
+        given(categoryRepository.existsByCategoryName(form.categoryName())).willReturn(false);
+
+        // when
+        categoryService.update(1L, form);
+
+        // then
+        assertThat(category.getCategoryName()).isEqualTo(newCategoryName);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
ref : #12 
> ex) #이슈번호, #이슈번호

## 작업 상세 내용
Category API 수정 로직입니다. 

- [x] 카테고리 수정 서비스 레이어 테스트 (카테고리 수정 시 이름 중복 실패 테스트, 성공 테스트, 존재하지 않는 카테고리)
- [x] 카테고리 수정 컨트롤러 레이어 테스트 (올바르지 않은 요청, 성공, 중복된 카테고리 이름)
- [ ] TODO

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

카테고리 수정 시에 엔티티 객체 안에서 유효성 검사 여부에 대해서 코멘트
- 안전하게 엔티티 객체 안에서도 유효성 검사를 해야하는가?